### PR TITLE
Added composer.json (identifying Plugin as a "wordpress-plugin")

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name"       : "joel-james/disqus-conditional-load",
+    "description": "Use Disqus comments with advanced features like lazy load, shortcode, widgets etc. Don't let Disqus to slow your site down.",
+    "homepage"   : "https://dclwp.com/",
+    "type"       : "wordpress-plugin",
+    "require"    : {
+        "composer/installers": "~1.0"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name"       : "joel-james/disqus-conditional-load",
     "description": "Use Disqus comments with advanced features like lazy load, shortcode, widgets etc. Don't let Disqus to slow your site down.",
     "homepage"   : "https://dclwp.com/",
+    "license"    : "GPL-2.0+",
     "type"       : "wordpress-plugin",
     "require"    : {
         "composer/installers": "~1.0"


### PR DESCRIPTION
Thanks for making such a useful plugin, @joel-james!

I like to build WordPress sites using [Bedrock](https://roots.io/bedrock/), requiring external dependencies (such as your own useful plugin!) via [Composer](https://getcomposer.org/). However, unless a plugin contains a `composer.json` file this [can be tricky](https://roots.io/wordpress-plugins-with-composer/).

By adding a basic `composer.json` your plugin can now be loaded via Composer with relatively little effort and correctly identifies itself as a `wordpress-plugin`. Yay! You're in good company as several big plugins do this too, e.g. [Jetpack](https://github.com/Automattic/jetpack/blob/master/composer.json) and [WordPress SEO](https://github.com/Yoast/wordpress-seo/blob/trunk/composer.json). 

I hope you're happy with this little enhancement... I don't think this will add too much of a maintenance burden as it shouldn't require anything more than a version bump when you tag each release.