### PR TITLE
Fix comments not opening in IE

### DIFF
--- a/assets/src/js/public/embed-click.js
+++ b/assets/src/js/public/embed-click.js
@@ -70,7 +70,7 @@ if ( disqus_button ) {
             document.getElementById( 'dcl_btn_container' ).appendChild( tmp_p );
         }
         // Remove button.
-        this.remove();
+        this.outerHTML = "";
         disqus_comments();
     };
 

--- a/assets/src/js/public/embed-count-click.js
+++ b/assets/src/js/public/embed-count-click.js
@@ -70,7 +70,7 @@ if ( disqus_button ) {
             document.getElementById( 'dcl_btn_container' ).appendChild( tmp_p );
         }
         // Remove button.
-        this.remove();
+        this.outerHTML = "";
         disqus_comments();
     };
 


### PR DESCRIPTION
Expanding comments was not working in Internet Explorer 11 due to it not supporting `remove()`:
```
SCRIPT438: Object doesn't support property or method 'remove'
embed-click.min.js (1,1202)
```
Previously reported this issue here: https://wordpress.org/support/topic/javascript-error-on-click-in-ie11/

Using this solution: https://stackoverflow.com/a/19298575