### PR TITLE
Add thread stub hook for possibility of custom pre-load injection

### DIFF
--- a/public/views/disqus-comments.php
+++ b/public/views/disqus-comments.php
@@ -16,8 +16,9 @@ defined( 'ABSPATH' ) || die( 'K. Bye.' );
  * @link       https://dclwp.com
  */
 ?>
+<?php global $dcl_helper; ?>
 <div id="disqus_thread">
-	<?php global $dcl_helper; ?>
+	<?php do_action( 'dcl_thread_stub' ); ?>
 	<?php if ( $dcl_helper->get_load_method() === 'click' ) : ?>
 		<div id="dcl_btn_container">
 			<button id='dcl_comment_btn' class="<?php echo esc_html( apply_filters( 'dcl_button_class', $dcl_helper->get_option( 'dcl_btn_class', false, '' ) ) ); ?>">


### PR DESCRIPTION
The purpose of this PR is to add a hook to the Disqus thread stub, allowing for customized pre-load behaviours.

Example, adding a loading animation or text before being replaced when Disqus is loaded. This could be useful to clients on a slow connection where even the time to Disqus logo isn't quick. The user may decide to move on if they don't see any hints of a commenting system.